### PR TITLE
Add tests for HotkeyListener, ScreenshotCapture and demo image

### DIFF
--- a/tests/test_hotkey_listener.py
+++ b/tests/test_hotkey_listener.py
@@ -1,0 +1,122 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Define mocks outside to be reusable or define inside fixture
+# We need to mock pynput and win32gui because they are not available/usable in this environment
+
+@pytest.fixture(scope="module")
+def hotkey_listener_module():
+    """
+    Patches sys.modules to mock pynput and win32gui, imports hotkey_listener,
+    and yields the module. Cleans up afterwards.
+    """
+    mock_pynput = MagicMock()
+    mock_keyboard = MagicMock()
+    mock_pynput.keyboard = mock_keyboard
+
+    # Mock Key enum
+    class MockKey:
+        f2 = 'f2'
+        esc = 'esc'
+    mock_keyboard.Key = MockKey
+    mock_keyboard.Listener = MagicMock()
+
+    mock_win32gui = MagicMock()
+
+    # Create a dict of modules to patch
+    modules_to_patch = {
+        'pynput': mock_pynput,
+        'pynput.keyboard': mock_keyboard,
+        'win32gui': mock_win32gui
+    }
+
+    with patch.dict(sys.modules, modules_to_patch):
+        if 'hotkey_listener' in sys.modules:
+            del sys.modules['hotkey_listener']
+
+        import hotkey_listener
+        yield hotkey_listener
+
+        # Cleanup
+        if 'hotkey_listener' in sys.modules:
+            del sys.modules['hotkey_listener']
+
+@pytest.fixture
+def listener(hotkey_listener_module):
+    """
+    Returns an instance of HotkeyListener with mocked callbacks.
+    """
+    hotkey_callback = MagicMock()
+    cancel_callback = MagicMock()
+    listener = hotkey_listener_module.HotkeyListener(
+        hotkey_callback=hotkey_callback,
+        cancel_callback=cancel_callback
+    )
+    # Attach mocks to instance for verification in tests
+    listener.mock_hotkey_callback = hotkey_callback
+    listener.mock_cancel_callback = cancel_callback
+    return listener
+
+def test_initialization(listener, hotkey_listener_module):
+    # Need to access MockKey from the module's mocked pynput
+    # But hotkey_listener_module.pynput is not exposed easily unless we inspect sys.modules or the module itself
+    # But we can check values
+    assert listener.hotkey_callback == listener.mock_hotkey_callback
+    assert listener.cancel_callback == listener.mock_cancel_callback
+    # The key is 'f2' because of our MockKey
+    assert listener.hotkey == 'f2'
+
+def test_is_chrome_active_always_true(listener):
+    # Current implementation returns True always inside try block
+    assert listener._is_chrome_active() is True
+
+def test_on_press_f2_triggers_callback(listener):
+    # Mock _is_chrome_active to ensure it's called
+    with patch.object(listener, '_is_chrome_active', return_value=True):
+        listener._on_press('f2')
+        listener.mock_hotkey_callback.assert_called_once()
+
+def test_on_press_f2_no_callback_if_chrome_not_active(listener):
+    # Even though current implementation always returns True, we can patch it to return False
+    # to test the logic flow
+    with patch.object(listener, '_is_chrome_active', return_value=False):
+        listener._on_press('f2')
+        listener.mock_hotkey_callback.assert_not_called()
+
+def test_on_press_other_key_does_nothing(listener):
+    listener._on_press('other_key')
+    listener.mock_hotkey_callback.assert_not_called()
+
+def test_on_release_esc_triggers_cancel(listener):
+    listener._on_release('esc')
+    listener.mock_cancel_callback.assert_called_once()
+
+def test_on_release_other_key_does_nothing(listener):
+    listener._on_release('other_key')
+    listener.mock_cancel_callback.assert_not_called()
+
+def test_start_starts_listener(listener):
+    # We need to access the mock_keyboard.Listener used by the module
+    # It was patched into sys.modules['pynput.keyboard']
+    # But getting it from sys.modules inside this test function might be tricky if patch context ended?
+    # No, fixture uses yield, so patch context is active during tests.
+
+    mock_listener_cls = sys.modules['pynput.keyboard'].Listener
+
+    listener.start()
+    mock_listener_cls.assert_called()
+    mock_listener_cls.return_value.__enter__.return_value.join.assert_called_once()
+
+def test_start_non_blocking_starts_listener(listener):
+    mock_listener_cls = sys.modules['pynput.keyboard'].Listener
+
+    listener_instance = listener.start_non_blocking()
+    mock_listener_cls.assert_called()
+    mock_listener_cls.return_value.start.assert_called_once()
+    assert listener_instance == mock_listener_cls.return_value
+
+def test_stop_stops_listener(listener):
+    listener.listener = MagicMock()
+    listener.stop()
+    listener.listener.stop.assert_called_once()

--- a/tests/test_screenshot_capture.py
+++ b/tests/test_screenshot_capture.py
@@ -1,0 +1,135 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+@pytest.fixture(scope="module")
+def screenshot_capture_module():
+    """
+    Patches sys.modules to mock mss, tkinter, and PIL, imports screenshot_capture,
+    and yields the module. Cleans up afterwards.
+    """
+    # Mock mss
+    mock_mss_pkg = MagicMock()
+    mock_mss_class = MagicMock()
+    mock_mss_instance = MagicMock()
+    mock_mss_class.return_value.__enter__.return_value = mock_mss_instance
+    mock_mss_pkg.mss = mock_mss_class
+
+    # Mock tkinter
+    mock_tkinter = MagicMock()
+
+    # Mock PIL
+    mock_PIL = MagicMock()
+    mock_Image = MagicMock()
+    mock_PIL.Image = mock_Image
+    mock_ImageTk = MagicMock()
+    mock_PIL.ImageTk = mock_ImageTk
+    mock_ImageDraw = MagicMock()
+    mock_PIL.ImageDraw = mock_ImageDraw
+
+    modules_to_patch = {
+        'mss': mock_mss_pkg,
+        'tkinter': mock_tkinter,
+        'PIL': mock_PIL
+    }
+
+    with patch.dict(sys.modules, modules_to_patch):
+        if 'screenshot_capture' in sys.modules:
+            del sys.modules['screenshot_capture']
+
+        import screenshot_capture
+        yield screenshot_capture
+
+        if 'screenshot_capture' in sys.modules:
+            del sys.modules['screenshot_capture']
+
+@pytest.fixture
+def capture_instance(screenshot_capture_module):
+    """
+    Returns a configured ScreenshotCapture instance.
+    """
+    with patch('os.makedirs') as mock_makedirs, \
+         patch('os.path.exists', return_value=False) as mock_exists:
+        capture = screenshot_capture_module.ScreenshotCapture(save_dir="test_screenshots")
+        return capture
+
+def test_init_creates_directory(screenshot_capture_module):
+    with patch('os.makedirs') as mock_makedirs, \
+         patch('os.path.exists', return_value=False) as mock_exists:
+        screenshot_capture_module.ScreenshotCapture(save_dir="new_dir")
+        mock_makedirs.assert_called_with("new_dir")
+
+def test_clear_directory(capture_instance):
+    with patch('os.path.exists', return_value=True), \
+         patch('os.listdir', return_value=["file1.png", "file2.txt"]), \
+         patch('os.path.isfile', return_value=True), \
+         patch('os.unlink') as mock_unlink:
+
+        capture_instance.clear_directory()
+        assert mock_unlink.call_count == 2
+
+def test_capture_fullscreen(capture_instance):
+    # Retrieve the mock instances from sys.modules
+    mock_mss_instance = sys.modules['mss'].mss.return_value.__enter__.return_value
+    mock_Image = sys.modules['PIL'].Image
+
+    # Setup mock behavior
+    mock_mss_instance.monitors = [{}]
+    mock_shot = MagicMock()
+    mock_shot.bgra = b'\x00' * 100
+    mock_shot.size = (10, 10)
+    mock_mss_instance.grab.return_value = mock_shot
+
+    mock_image = MagicMock()
+    mock_Image.frombytes.return_value = mock_image
+
+    result = capture_instance.capture_fullscreen()
+
+    mock_mss_instance.grab.assert_called_once()
+    mock_Image.frombytes.assert_called_once()
+    assert result == mock_image
+
+def test_save_screenshot(capture_instance):
+    mock_image = MagicMock()
+    # patch datetime inside the module
+    with patch('screenshot_capture.datetime') as mock_datetime:
+        mock_datetime.now.return_value.strftime.return_value = "20230101_120000"
+
+        filepath = capture_instance.save_screenshot(mock_image)
+
+        mock_image.save.assert_called_once()
+        assert "screenshot_20230101_120000.png" in str(filepath)
+        assert capture_instance.save_dir in str(filepath)
+
+def test_capture_region_interactive_success(capture_instance):
+    mock_fullscreen = MagicMock()
+    mock_region_image = MagicMock()
+    mock_coords = (10, 10, 50, 50)
+
+    with patch.object(capture_instance, 'capture_fullscreen', return_value=mock_fullscreen), \
+         patch('screenshot_capture.RegionSelector') as mock_selector_cls:
+
+        mock_selector = mock_selector_cls.return_value
+        mock_selector.get_region.return_value = mock_coords
+
+        mock_fullscreen.crop.return_value = mock_region_image
+
+        img, region = capture_instance.capture_region_interactive()
+
+        assert img == mock_region_image
+        assert region == mock_coords
+        mock_fullscreen.crop.assert_called_with(mock_coords)
+
+def test_capture_region_interactive_cancel(capture_instance):
+    mock_fullscreen = MagicMock()
+
+    with patch.object(capture_instance, 'capture_fullscreen', return_value=mock_fullscreen), \
+         patch('screenshot_capture.RegionSelector') as mock_selector_cls:
+
+        mock_selector = mock_selector_cls.return_value
+        mock_selector.get_region.return_value = None
+
+        img, region = capture_instance.capture_region_interactive()
+
+        assert img is None
+        assert region is None

--- a/tests/test_square_detector.py
+++ b/tests/test_square_detector.py
@@ -101,3 +101,11 @@ def test_detection_with_light_cyan_4_image(detector):
         os.path.join("tests", "light_cyan_4.png"),
         expected_count=4
     )
+
+def test_detection_with_demo_image(detector):
+    """Test detection with assets/demo.png - should detect exactly 17 squares."""
+    verify_square_detection(
+        detector,
+        os.path.join("assets", "demo.png"),
+        expected_count=17
+    )


### PR DESCRIPTION
This PR expands the test coverage by adding:
1. A new test case for `assets/demo.png` in the existing `test_square_detector.py` to verify detection on a realistic demo image.
2. A new test file `tests/test_hotkey_listener.py` which mocks `pynput` and `win32gui` to test `HotkeyListener` logic without needing actual input devices or Windows platform.
3. A new test file `tests/test_screenshot_capture.py` which mocks `mss`, `tkinter`, and `PIL` to test `ScreenshotCapture` functionality including directory management and screenshot saving.

These additions ensure that the core components of the application have unit test coverage and can be tested in a CI environment.

---
*PR created automatically by Jules for task [7909892437995659852](https://jules.google.com/task/7909892437995659852) started by @Debiancc*